### PR TITLE
Multi-Client Support for Internal Reconnect Handler

### DIFF
--- a/K_Relay/FrmMainMetro.cs
+++ b/K_Relay/FrmMainMetro.cs
@@ -101,7 +101,8 @@ namespace K_Relay
                 btnToggleProxy.Text = "Stop Proxy";
                 SetStatus("Starting...", Color.Black);
 
-                _proxy.RemoteAddress = Serializer.Servers[Config.Default.DefaultServerName];
+                _proxy.defServer = Config.Default.DefaultServerName;
+                _proxy.defTempServer = Serializer.Servers[_proxy.defServer];
 
                 _proxy.Start();
             }

--- a/K_Relay/K_Relay.csproj
+++ b/K_Relay/K_Relay.csproj
@@ -91,12 +91,11 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Util\ConClient.cs" />
     <Compile Include="Util\FrmServerReconnect.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="Util\FrmServerReconnect.Designer.cs">
-      <DependentUpon>FrmServerReconnect.cs</DependentUpon>
-    </Compile>
+    <Compile Include="Util\FrmServerReconnect.Designer.cs" />
     <Compile Include="Util\PacketDebugger.cs" />
     <Compile Include="Util\ReconnectHandler.cs" />
     <Compile Include="Util\TextBoxStreamWriter.cs" />
@@ -116,9 +115,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <EmbeddedResource Include="Util\FrmServerReconnect.resx">
-      <DependentUpon>FrmServerReconnect.cs</DependentUpon>
-    </EmbeddedResource>
+    <EmbeddedResource Include="Util\FrmServerReconnect.resx" />
     <None Include="Config.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Config.Designer.cs</LastGenOutput>

--- a/K_Relay/Util/ConClient.cs
+++ b/K_Relay/Util/ConClient.cs
@@ -1,0 +1,86 @@
+﻿using Lib_K_Relay;
+using Lib_K_Relay.Interface;
+using Lib_K_Relay.Networking;
+using Lib_K_Relay.Networking.Packets;
+using Lib_K_Relay.Networking.Packets.Client;
+using Lib_K_Relay.Networking.Packets.Server;
+using Lib_K_Relay.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.IO;
+
+namespace K_Relay.Util
+{
+    public class ConClient
+    {
+        public Proxy _proxy;
+        public Client _toConnect;
+        public string currentServ = " ";
+        public string lastRealm = " ";
+
+        public ConClient(Proxy proxy, Client client)
+        {
+            _toConnect = client;
+            _proxy = proxy;
+            currentServ = _proxy.defServer;
+            lastRealm = "Nexus";
+            Save(currentServ);
+        }
+
+        public void setCurrentServer(string serv)
+        {
+            currentServ = serv;
+
+            Save(currentServ);
+        }
+
+        public void setRealm(string realm)
+        {
+            lastRealm = realm;
+
+            Save(currentServ);
+        }
+
+        public void Save(string text)
+        {
+            string path = Directory.GetCurrentDirectory();
+            path += "\\Plugins\\";
+            Directory.CreateDirectory(path);
+            path += "CurrentServers.txt";
+            if (!File.Exists(path))
+            {
+                File.WriteAllLines(path, new string[] { String.Empty });
+            }
+            string[] lines = File.ReadAllLines(path);
+            bool found = false;
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                string[] values = line.Split(',');
+                if (values[0] == _toConnect.PlayerData.Name)
+                {
+                    found = true;
+                    lines[i] = _toConnect.PlayerData.Name + "," + text + "," + lastRealm;
+                }
+            }
+            File.WriteAllLines(path, new string[] { String.Empty });
+            File.WriteAllLines(path, lines);
+            if (!found)
+            {
+                using (StreamWriter file = File.AppendText(path))
+                {
+                    file.WriteLine(_toConnect.PlayerData.Name + "," + text + "," + lastRealm);
+                }
+            }
+        }
+
+        public ReconnectPacket _recon = (ReconnectPacket)Packet.Create(PacketType.RECONNECT);
+        public ReconnectPacket _drecon = (ReconnectPacket)Packet.Create(PacketType.RECONNECT);
+    }
+}

--- a/K_Relay/Util/FrmServerReconnect.cs
+++ b/K_Relay/Util/FrmServerReconnect.cs
@@ -9,16 +9,25 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
+using Lib_K_Relay;
+using Lib_K_Relay.Interface;
+using Lib_K_Relay.Networking;
+using Lib_K_Relay.Networking.Packets;
+using Lib_K_Relay.Networking.Packets.Client;
+using Lib_K_Relay.Networking.Packets.Server;
+using Lib_K_Relay.Utilities;
+
 namespace K_Relay.Util
 {
     public partial class FrmServerReconnect : Form
     {
         private ReconnectHandler _r;
-
-        public FrmServerReconnect(ReconnectHandler r)
+        private Client client;
+        public FrmServerReconnect(ReconnectHandler r, Client c)
         {
             InitializeComponent();
             _r = r;
+            client = c;
 
             listServers.SuspendLayout();
             foreach (var pair in Serializer.Servers)
@@ -33,7 +42,7 @@ namespace K_Relay.Util
             string name = listServers.Items[listServers.SelectedIndex].ToString();
             string server = Serializer.Servers[name];
 
-            _r.ChangeServer(server, name);
+            _r.ChangeServer(server, name, client);
             this.Close();
         }
 

--- a/K_Relay/Util/ReconnectHandler.cs
+++ b/K_Relay/Util/ReconnectHandler.cs
@@ -137,7 +137,13 @@ namespace K_Relay.Util
                 _proxy.Port = reconnect.Port;
 
             if (reconnect.Host != "")
+            {
                 _proxy.defTempServer = reconnect.Host;
+            }
+            else
+            {
+                _proxy.defTempServer = _proxy.getRemoteAddress(client);
+            }
 
             // Tell the client to connect to the proxy
             reconnect.Host = "localhost";
@@ -196,7 +202,7 @@ namespace K_Relay.Util
         {
             string host = reconnect.Host;
             int port = reconnect.Port;
-            _proxy.defTempServer = host;
+            if (!host.ToLower().Contains("localhost")) _proxy.defTempServer = host;
             _proxy.Port = port;
             reconnect.Host = "localhost";
             reconnect.Port = 2050;

--- a/K_Relay/Util/ReconnectHandler.cs
+++ b/K_Relay/Util/ReconnectHandler.cs
@@ -19,44 +19,66 @@ namespace K_Relay.Util
     public class ReconnectHandler : IPlugin
     {
         private Proxy _proxy;
-        private Client _toConnect;
 
-        private ReconnectPacket _recon = (ReconnectPacket)Packet.Create(PacketType.RECONNECT);
-        private ReconnectPacket _drecon = (ReconnectPacket)Packet.Create(PacketType.RECONNECT);
+        private Dictionary<string, ConClient> clients = new Dictionary<string, ConClient>();
 
         public string GetAuthor()
-        { return "KrazyShank / Kronks"; }
+        { return "Juix & KrazyShank"; }
 
         public string GetName()
-        { return "Internal Reconnect Handler"; }
+        { return "Multi-Client Reconnect Handler"; }
 
         public string GetDescription()
-        { return "Changes the host name to that of the entered portal.\n" +
-                   "Required to be able to enter portals.\n" +
-                   "Use /connect ingame to change server.\n" +
-                   "Use /recon to reconnect to your last realm.\n" +
-                   "Use /drecon to reconnect to your last dungeon.\n"; }
+        {
+            return "Changes the host name to that of the entered portal.\n" +
+                     "Required to be able to enter portals.\n" +
+                     "Use /connect ingame to change server.\n" +
+                     "Use /recon to reconnect to your last realm.\n" +
+                     "Use /drecon to reconnect to your last dungeon.\n" +
+                     "Use /serv to display your current server.\n";
+        }
 
         public string[] GetCommands()
-        { return new string[] { "/connect", "/recon", "/drecon" }; }
+        { return new string[] { "/connect", "/recon", "/drecon", "/serv" }; }
 
         public void Initialize(Proxy proxy)
         {
             _proxy = proxy;
             proxy.HookPacket(PacketType.RECONNECT, OnReconnect);
             proxy.HookPacket(PacketType.CREATESUCCESS, OnCreateSuccess);
+            proxy.HookCommand("serv", OnServCommand);
             proxy.HookCommand("connect", OnConnectCommand);
             proxy.HookCommand("recon", OnReconnectCommand);
             proxy.HookCommand("drecon", OnDReconnectCommand);
         }
 
+        private ConClient getClient(Client client)
+        {
+            if (clients.ContainsKey(client.PlayerData.Name))
+            {
+                return clients[client.PlayerData.Name];
+            }
+            else
+            {
+                clients[client.PlayerData.Name] = new ConClient(_proxy, client);
+                return clients[client.PlayerData.Name];
+            }
+        }
+
         private void OnCreateSuccess(Client client, Packet packet)
         {
+            ConClient _c = getClient(client);
+
             // Send welcome message to player
             string message = "Welcome to K Relay!";
             foreach (var pair in Serializer.Servers)
-                if (pair.Value == _proxy.RemoteAddress)
+            {
+                if (pair.Value == _proxy.getRemoteAddress(client))
+                {
                     message += "\\n" + pair.Key;
+                    _c.setCurrentServer(pair.Key);
+                }
+            }
 
             PluginUtils.Delay(1500, () => client.SendToClient(
                 PluginUtils.CreateNotification(client.ObjectId, message)));
@@ -64,6 +86,8 @@ namespace K_Relay.Util
 
         private void OnReconnect(Client client, Packet packet)
         {
+            ConClient _c = getClient(client);
+
             ReconnectPacket reconnect = packet as ReconnectPacket;
 
             if (reconnect.Host.Contains(".com"))
@@ -71,72 +95,108 @@ namespace K_Relay.Util
 
             if (reconnect.Name.ToLower().Contains("nexusportal"))
             {
-                _recon.IsFromArena = false;
-                _recon.GameId = reconnect.GameId;
-                _recon.Host = (reconnect.Host == "" ? _proxy.RemoteAddress : reconnect.Host);
-                _recon.Port = (reconnect.Port == -1 ? _proxy.Port : reconnect.Port);
-                _recon.Key = reconnect.Key;
-                _recon.KeyTime = reconnect.KeyTime;
-                _recon.Name = reconnect.Name;
+                _c._recon.IsFromArena = false;
+                _c._recon.GameId = reconnect.GameId;
+                _c._recon.Host = (reconnect.Host == "" ? _proxy.getRemoteAddress(client) : reconnect.Host);
+                _c._recon.Port = (reconnect.Port == -1 ? _proxy.Port : reconnect.Port);
+                _c._recon.Key = reconnect.Key;
+                _c._recon.KeyTime = reconnect.KeyTime;
+                _c._recon.Name = reconnect.Name;
+                string[] names = reconnect.Name.Split('.');
+                _c.setRealm(names[1]);
             }
             else if (reconnect.Name != "" && !reconnect.Name.Contains("vault") && reconnect.GameId != -2)
             {
-                _drecon.IsFromArena = false;
-                _drecon.GameId = reconnect.GameId;
-                _drecon.Host = (reconnect.Host == "" ? _proxy.RemoteAddress : reconnect.Host);
-                _drecon.Port = (reconnect.Port == -1 ? _proxy.Port : reconnect.Port);
-                _drecon.Key = reconnect.Key;
-                _drecon.KeyTime = reconnect.KeyTime;
-                _drecon.Name = reconnect.Name;
+                _c._drecon.IsFromArena = false;
+                _c._drecon.GameId = reconnect.GameId;
+                _c._drecon.Host = (reconnect.Host == "" ? _proxy.getRemoteAddress(client) : reconnect.Host);
+                _c._drecon.Port = (reconnect.Port == -1 ? _proxy.Port : reconnect.Port);
+                _c._drecon.Key = reconnect.Key;
+                _c._drecon.KeyTime = reconnect.KeyTime;
+                _c._drecon.Name = reconnect.Name;
+            }
+
+            if (reconnect.Name.ToLower().Contains("nexus") && !reconnect.Name.ToLower().Contains("portal"))
+            {
+                _c.setRealm("Nexus");
+            }
+            else if (reconnect.Name.ToLower().Contains("vault"))
+            {
+                _c.setRealm("Vault");
+            }
+            else if (reconnect.Name.ToLower().Contains("pet"))
+            {
+                _c.setRealm("Pet Yard");
+            }
+            else if (reconnect.Name.ToLower().Contains("guild"))
+            {
+                _c.setRealm("Guild Hall");
             }
 
             if (reconnect.Port != -1)
                 _proxy.Port = reconnect.Port;
 
             if (reconnect.Host != "")
-                _proxy.RemoteAddress = reconnect.Host;
+                _proxy.defTempServer = reconnect.Host;
 
             // Tell the client to connect to the proxy
             reconnect.Host = "localhost";
             reconnect.Port = 2050;
         }
 
+        private void OnServCommand(Client client, string command, string[] args)
+        {
+            ConClient _c = getClient(client);
+
+            client.SendToClient(PluginUtils.CreateNotification(client.ObjectId, _c.currentServ + " " + _c.lastRealm));
+        }
+
         private void OnConnectCommand(Client client, string command, string[] args)
         {
-            _toConnect = client;
-            PluginUtils.ShowGUI(new FrmServerReconnect(this));
+            ConClient _c = getClient(client);
+
+            _c._toConnect = client;
+            PluginUtils.ShowGUI(new FrmServerReconnect(this, client));
         }
 
         private void OnReconnectCommand(Client client, string command, string[] args)
         {
-            SendReconnect(_recon, client);
+            ConClient _c = getClient(client);
+
+            SendReconnect(_c._recon, client);
         }
 
         private void OnDReconnectCommand(Client client, string command, string[] args)
         {
-            SendReconnect(_drecon, client);
+            ConClient _c = getClient(client);
+
+            SendReconnect(_c._drecon, client);
         }
 
-        public void ChangeServer(string address, string name)
+        public void ChangeServer(string address, string name, Client client)
         {
+            ConClient _c = getClient(client);
+
             Console.WriteLine("[Reconnect Handler] Changing to server {0}({1}).", name, address);
             ReconnectPacket reconnect = (ReconnectPacket)Packet.Create(PacketType.RECONNECT);
             reconnect.Host = address;
             reconnect.Port = 2050;
             reconnect.GameId = -2;
             reconnect.Name = "Connecting to " + name;
+            _c.setCurrentServer(name);
+            _c.setRealm("Nexus");
 
             reconnect.IsFromArena = false;
             reconnect.Key = new byte[0];
             reconnect.KeyTime = 0;
-            SendReconnect(reconnect, _toConnect);
+            SendReconnect(reconnect, _c._toConnect);
         }
 
         private void SendReconnect(ReconnectPacket reconnect, Client client)
         {
             string host = reconnect.Host;
             int port = reconnect.Port;
-            _proxy.RemoteAddress = host;
+            _proxy.defTempServer = host;
             _proxy.Port = port;
             reconnect.Host = "localhost";
             reconnect.Port = 2050;
@@ -145,6 +205,16 @@ namespace K_Relay.Util
 
             reconnect.Host = host;
             reconnect.Port = port;
+        }
+
+        private string ServerNameFromHost(string host)
+        {
+            KeyValuePair<string, string>[] servers = Serializer.Servers.ToArray();
+            foreach (KeyValuePair<string, string> pair in servers)
+            {
+                if (pair.Value == host) return pair.Key;
+            }
+            return "";
         }
     }
 }

--- a/Lib K Relay/Networking/Client.cs
+++ b/Lib K Relay/Networking/Client.cs
@@ -55,9 +55,10 @@ namespace Lib_K_Relay.Networking
 
             char[] libA = lib.ToCharArray();
 
+            Random rnd = new Random();
+
             for (int i = 0; i < length; i++)
             {
-                Random rnd = new Random();
                 rand += libA[rnd.Next(0, libA.Length)];
             }
 

--- a/Lib K Relay/Networking/Client.cs
+++ b/Lib K Relay/Networking/Client.cs
@@ -33,8 +33,11 @@ namespace Lib_K_Relay.Networking
         private TcpClient _remoteConnection;
         private Proxy _proxy;
 
+        public string uniqueCode = getRandString(20);
+
         public Client(Proxy proxy, TcpClient client)
         {
+            uniqueCode = getRandString(20);
             _proxy = proxy;
             _localConnection = client;
             _remoteConnection = new TcpClient();
@@ -45,10 +48,26 @@ namespace Lib_K_Relay.Networking
             ServerSendKey = new RC4(_proxy.Key0);
         }
 
+        private static string getRandString(int length)
+        {
+            string lib = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+            string rand = "";
+
+            char[] libA = lib.ToCharArray();
+
+            for (int i = 0; i < length; i++)
+            {
+                Random rnd = new Random();
+                rand += libA[rnd.Next(0, libA.Length)];
+            }
+
+            return rand;
+        }
+
         public void Connect()
         {
             _remoteConnection.BeginConnect(
-                IPAddress.Parse(_proxy.RemoteAddress),
+                IPAddress.Parse(_proxy.getRemoteAddress(this)),
                 _proxy.Port, RemoteConnected, null);
             _proxy.FireClientConnected(this);
         }

--- a/Lib K Relay/Proxy.cs
+++ b/Lib K Relay/Proxy.cs
@@ -19,7 +19,9 @@ namespace Lib_K_Relay
     {
         public int Port = 2050;
         public string ListenAddress = "127.0.0.1";
-        public string RemoteAddress = "54.241.208.233"; // USW
+        public string defServer = "USWest";
+        public string defTempServer = Serializer.Servers["USWest"];
+        public Dictionary<string, string> RemoteAddresses = new Dictionary<string, string>(); // USW
         public string Key0 = "311f80691451c71d09a13a2a6e";
         public string Key1 = "72c5583cafb6818995cdd74b80";
 
@@ -46,7 +48,7 @@ namespace Lib_K_Relay
         private TcpListener _localListener = null;
 
         /// <summary>
-        /// Starts listening for clients on the defined port and host at 127.0.0.1:250
+        /// Starts listening for clients on the defined port and host at 127.0.0.1:2050
         /// </summary>
         public void Start()
         {
@@ -63,6 +65,44 @@ namespace Lib_K_Relay
                 if (ProxyListenStarted != null) ProxyListenStarted(this);
             }
             catch (Exception e) { PluginUtils.LogPluginException(e, "ProxyListenStarted"); }
+        }
+
+        public static string ServerNameFromHost(string host)
+        {
+            KeyValuePair<string, string>[] servers = Serializer.Servers.ToArray();
+            foreach (KeyValuePair<string, string> pair in servers)
+            {
+                if (pair.Value == host) return pair.Key;
+            }
+            return "";
+        }
+
+        public string getRemoteAddress(Client client)
+        {
+            if (RemoteAddresses.ContainsKey(client.uniqueCode))
+            {
+                return RemoteAddresses[client.uniqueCode];
+            }
+            else
+            {
+                RemoteAddresses[client.uniqueCode] = defTempServer;
+                defTempServer = Serializer.Servers[defServer];
+                return RemoteAddresses[client.uniqueCode];
+            }
+        }
+
+        public void setRemoteAddress(Client client, string value)
+        {
+            RemoteAddresses[client.uniqueCode] = value;
+        }
+
+        public void setAllAddresses(string add)
+        {
+            string[] adds = RemoteAddresses.Values.ToArray();
+            for (int i = 0; i < adds.Length; i++)
+            {
+                adds[i] = add;
+            }
         }
 
         public void Stop()


### PR DESCRIPTION
I have added multi-client support for the Internal Reconnect Handler.
Before when you'd have the first  client connect to the default server,
then change their server to a different one, the other incoming client
would join the server he changed to. Now clients connecting for the
first time go to the default server. Also each client has their own
recon/drecon.